### PR TITLE
Make queue reference immutable in draw API

### DIFF
--- a/examples/clipping.rs
+++ b/examples/clipping.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let surface = unsafe { instance.create_surface(&window) };
 
     // Initialize GPU
-    let (device, mut queue) = futures::executor::block_on(async {
+    let (device, queue) = futures::executor::block_on(async {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -136,7 +136,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 glyph_brush
                     .draw_queued(
                         &device,
-                        &mut queue,
+                        &queue,
                         &mut encoder,
                         view,
                         size.width,
@@ -157,7 +157,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 glyph_brush
                     .draw_queued_with_transform_and_scissoring(
                         &device,
-                        &mut queue,
+                        &queue,
                         &mut encoder,
                         view,
                         wgpu_glyph::orthographic_projection(

--- a/examples/depth.rs
+++ b/examples/depth.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let surface = unsafe { instance.create_surface(&window) };
 
     // Initialize GPU
-    let (device, mut queue) = futures::executor::block_on(async {
+    let (device, queue) = futures::executor::block_on(async {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -151,7 +151,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 glyph_brush
                     .draw_queued(
                         &device,
-                        &mut queue,
+                        &queue,
                         &mut encoder,
                         view,
                         wgpu::RenderPassDepthStencilAttachment {

--- a/examples/hello.rs
+++ b/examples/hello.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     let surface = unsafe { instance.create_surface(&window) };
 
     // Initialize GPU
-    let (device, mut queue) = futures::executor::block_on(async {
+    let (device, queue) = futures::executor::block_on(async {
         let adapter = instance
             .request_adapter(&wgpu::RequestAdapterOptions {
                 power_preference: wgpu::PowerPreference::HighPerformance,
@@ -145,7 +145,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 glyph_brush
                     .draw_queued(
                         &device,
-                        &mut queue,
+                        &queue,
                         &mut encoder,
                         view,
                         size.width,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ where
     fn process_queued(
         &mut self,
         device: &wgpu::Device,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         region: Option<Region>,
     ) {
         let pipeline = &mut self.pipeline;
@@ -238,7 +238,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     pub fn draw_queued(
         &mut self,
         device: &wgpu::Device,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         target_width: u32,
@@ -268,7 +268,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     pub fn draw_queued_with_transform(
         &mut self,
         device: &wgpu::Device,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         transform: [f32; 16],
@@ -294,7 +294,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<(), F, H> {
     pub fn draw_queued_with_transform_and_scissoring(
         &mut self,
         device: &wgpu::Device,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         transform: [f32; 16],
@@ -344,7 +344,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
     pub fn draw_queued(
         &mut self,
         device: &wgpu::Device,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,
@@ -376,7 +376,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
     pub fn draw_queued_with_transform(
         &mut self,
         device: &wgpu::Device,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,
@@ -409,7 +409,7 @@ impl<F: Font + Sync, H: BuildHasher> GlyphBrush<wgpu::DepthStencilState, F, H> {
     pub fn draw_queued_with_transform_and_scissoring(
         &mut self,
         device: &wgpu::Device,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -42,7 +42,7 @@ impl Pipeline<()> {
 
     pub fn draw(
         &mut self,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         transform: [f32; 16],
@@ -72,7 +72,7 @@ impl Pipeline<wgpu::DepthStencilState> {
 
     pub fn draw(
         &mut self,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         encoder: &mut wgpu::CommandEncoder,
         target: &wgpu::TextureView,
         depth_stencil_attachment: wgpu::RenderPassDepthStencilAttachment,
@@ -92,7 +92,7 @@ impl Pipeline<wgpu::DepthStencilState> {
 impl<Depth> Pipeline<Depth> {
     pub fn update_cache(
         &mut self,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         offset: [u16; 2],
         size: [u16; 2],
         data: &[u8],
@@ -120,7 +120,7 @@ impl<Depth> Pipeline<Depth> {
     pub fn upload(
         &mut self,
         device: &wgpu::Device,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         instances: &mut [Instance],
         region: Option<Region>,
     ) {
@@ -215,7 +215,9 @@ fn build<D>(
                 wgpu::BindGroupLayoutEntry {
                     binding: 1,
                     visibility: wgpu::ShaderStages::FRAGMENT,
-                    ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                    ty: wgpu::BindingType::Sampler(
+                        wgpu::SamplerBindingType::Filtering,
+                    ),
                     count: None,
                 },
                 wgpu::BindGroupLayoutEntry {
@@ -330,7 +332,7 @@ fn build<D>(
 
 fn draw<D>(
     pipeline: &mut Pipeline<D>,
-    queue: &mut wgpu::Queue,
+    queue: &wgpu::Queue,
     encoder: &mut wgpu::CommandEncoder,
     target: &wgpu::TextureView,
     depth_stencil_attachment: Option<wgpu::RenderPassDepthStencilAttachment>,

--- a/src/pipeline/cache.rs
+++ b/src/pipeline/cache.rs
@@ -29,7 +29,7 @@ impl Cache {
 
     pub fn update(
         &mut self,
-        queue: &mut wgpu::Queue,
+        queue: &wgpu::Queue,
         offset: [u16; 2],
         size: [u16; 2],
         data: &[u8],


### PR DESCRIPTION
The API can be a bit more general if this reference is immutable, in fact, the examples work with no changes (but I did change them since it didn't need to be mutable anymore).